### PR TITLE
Removed an X and O from all fixtures

### DIFF
--- a/spec/tictactoe.spec.js
+++ b/spec/tictactoe.spec.js
@@ -13,7 +13,7 @@ describe('Tic Tac Toe Functionality', function() {
       spyOn(window, "doTurn");
       $(selector).click();
       expect(window.doTurn).toHaveBeenCalled();
-    });     
+    });
   });
 
   describe( "#doTurn", function() {
@@ -31,13 +31,13 @@ describe('Tic Tac Toe Functionality', function() {
       expect(turn).toEqual(1);
       expect(window.updateState).toHaveBeenCalled;
       expect(window.checkWinner).toHaveBeenCalled;
-    });     
+    });
   });
 
   describe( "#player", function() {
     it("should return the mark of the current player when player is X", function() {
       expect(player()).toEqual("X");
-    });     
+    });
     it("should return the mark of the current player when player is O", function() {
       turn = 1;
       expect(player()).toEqual("O");
@@ -51,7 +51,7 @@ describe('Tic Tac Toe Functionality', function() {
       var selector = '[data-x="0"][data-y="0"]';
       $(selector).click();
       expect($(selector).html()).toEqual("X");
-    }); 
+    });
 
     it("calls on `player()`", function() {
       setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0"></td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1"></td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table></body>');
@@ -60,7 +60,7 @@ describe('Tic Tac Toe Functionality', function() {
       var selector = '[data-x="1"][data-y="0"]';
       $(selector).click();
       expect(window.player).toHaveBeenCalled();
-    });     
+    });
   });
 
   describe( "#message", function() {
@@ -70,7 +70,7 @@ describe('Tic Tac Toe Functionality', function() {
       var string = "Player X Won!";
       message(string);
       expect($("#message").html()).toEqual(string);
-    });     
+    });
   });
 
   describe( "#checkWinner", function() {
@@ -82,8 +82,8 @@ describe('Tic Tac Toe Functionality', function() {
       $(selector).click()
       var selector = '[data-x="0"][data-y="1"]'
       $(selector).click()
-      expect(checkWinner()).toEqual(false)   
-    });     
+      expect(checkWinner()).toEqual(false)
+    });
 
     it("calls on 'message' and passes it the string 'Player X Won!' when player X wins vertically", function() {
       setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0"></td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1"></td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table></body>');
@@ -96,7 +96,7 @@ describe('Tic Tac Toe Functionality', function() {
       $('[data-x="0"][data-y="2"]').click();
       // _X_|_O_|_O_
       // _X_|___|___
-      //  X |   |   
+      //  X |   |
       expect(window.message).toHaveBeenCalledWith("Player X Won!");
     });
 
@@ -111,8 +111,8 @@ describe('Tic Tac Toe Functionality', function() {
       $('[data-x="2"][data-y="2"]').click();
       // _X_|_O_|_O_
       // ___|_X_|___
-      //    |   | X 
-      expect(window.message).toHaveBeenCalledWith("Player X Won!"); 
+      //    |   | X
+      expect(window.message).toHaveBeenCalledWith("Player X Won!");
     });
   });
 
@@ -150,15 +150,15 @@ describe('Tic Tac Toe Functionality', function() {
       $('[data-x="2"][data-y="2"]').click();
       // _O_|_X_|_X_
       // ___|_O_|___
-      //    | X | O 
+      //    | X | O
       expect($("#message").html()).toEqual("Player O Won!");
       // ___|___|___
       // ___|___|___
-      //    |   |   
+      //    |   |
       expect(turn).toEqual(0);
       $("td").each(function() {
         expect($(this).html()).toEqual("")
-      }); 
+      });
     });
 
     it("resets the board and sets turn to zero when there is a tie", function() {
@@ -175,15 +175,15 @@ describe('Tic Tac Toe Functionality', function() {
       $('[data-x="2"][data-y="0"]').click();
       // _X_|_O_|_X_
       // _O_|_O_|_X_
-      //  X | X | O 
+      //  X | X | O
       expect($("#message").html()).toEqual("Tie game");
       // ___|___|___
       // ___|___|___
-      //    |   |   
+      //    |   |
       expect(turn).toEqual(0);
       $("td").each(function() {
         expect($(this).html()).toEqual("")
-      });  
+      });
     });
 
     it("allows client to play multiple game", function() {
@@ -200,11 +200,11 @@ describe('Tic Tac Toe Functionality', function() {
       $('[data-x="2"][data-y="0"]').click();
       // _X_|_O_|_X_
       // _O_|_O_|_X_
-      //  X | X | O 
+      //  X | X | O
       expect($("#message").html()).toEqual("Tie game");
       // ___|___|___
       // ___|___|___
-      //    |   |   
+      //    |   |
       expect(turn).toEqual(0);
       $("td").each(function() {
         expect($(this).html()).toEqual("")
@@ -217,18 +217,18 @@ describe('Tic Tac Toe Functionality', function() {
       $('[data-x="2"][data-y="2"]').click();
       // _O_|_X_|_X_
       // ___|_O_|___
-      //    | X | O 
+      //    | X | O
       expect($("#message").html()).toEqual("Player O Won!");
       // ___|___|___
       // ___|___|___
-      //    |   |   
+      //    |   |
       expect(turn).toEqual(0);
       $("td").each(function() {
         expect($(this).html()).toEqual("")
       });
     });
   });
-}); 
+});
 
 
 describe('#integration tests of persistence', function() {
@@ -237,7 +237,7 @@ describe('#integration tests of persistence', function() {
     currentGame = 0;
   });
   it("if i click the getAllGames button it should send a get request to /games", function() {
-    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0">X</td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1">O</td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
+    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0"></td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1"></td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
     attachListeners()
     jasmine.Ajax.withMock(function() {
       $('#previous').click()
@@ -248,7 +248,7 @@ describe('#integration tests of persistence', function() {
   });
 
   it("if i click the save game button it should post to /games", function() {
-    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0">X</td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1">O</td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
+    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0"></td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1"></td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
     attachListeners()
     jasmine.Ajax.withMock(function() {
       $('#save').click()
@@ -259,7 +259,7 @@ describe('#integration tests of persistence', function() {
   });
 
   it("if i click the save game button a second time it should send a PATCH to /games/:id", function() {
-    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0">X</td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1">O</td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
+    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0"></td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1"></td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
     attachListeners()
     jasmine.Ajax.withMock(function() {
       var data = {
@@ -269,7 +269,7 @@ describe('#integration tests of persistence', function() {
         }
       }
       var response = {
-        "status": 200, 
+        "status": 200,
         "contentType": 'application/json',
         "responseText" : JSON.stringify(data)
       }
@@ -283,7 +283,7 @@ describe('#integration tests of persistence', function() {
   });
 
   it("if i click the previous game button and no games have been saved i should get no games in the DOM", function() {
-    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0">X</td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1">O</td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
+    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0"></td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1"></td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
     attachListeners()
     expect($("#games").children().length).toBe(0);
     jasmine.Ajax.withMock(function() {
@@ -291,7 +291,7 @@ describe('#integration tests of persistence', function() {
         games: []
       }
       var response = {
-        "status": 200, 
+        "status": 200,
         "contentType": 'application/json',
         "responseText" : JSON.stringify(data)
       }
@@ -302,7 +302,7 @@ describe('#integration tests of persistence', function() {
   });
 
   it("if i click the previous game button and a game has already been saved it should add the previous game to the DOM", function() {
-    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0">X</td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1">O</td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
+    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0"></td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1"></td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
     attachListeners()
     expect($("#games").children().length).toBe(0);
     jasmine.Ajax.withMock(function() {
@@ -313,7 +313,7 @@ describe('#integration tests of persistence', function() {
         }]
       }
       var response = {
-        "status": 200, 
+        "status": 200,
         "contentType": 'application/json',
         "responseText" : JSON.stringify(data)
       }
@@ -321,10 +321,10 @@ describe('#integration tests of persistence', function() {
       jasmine.Ajax.requests.mostRecent().respondWith(response);
       expect($("#games").children().length).toBe(1);
     });
-  }); 
+  });
 
   it("if i click save it should persist the game so that when i asked for previous games i should get one more in the DOM", function() {
-    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0">X</td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1">O</td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
+    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0"></td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1"></td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
     attachListeners()
     expect($("#games").children().length).toBe(0);
     jasmine.Ajax.withMock(function() {
@@ -335,7 +335,7 @@ describe('#integration tests of persistence', function() {
         }]
       }
       var response = {
-        "status": 200, 
+        "status": 200,
         "contentType": 'application/json',
         "responseText" : JSON.stringify(data)
       }
@@ -347,7 +347,7 @@ describe('#integration tests of persistence', function() {
         games: [{
           id:1,
           state: ["X","","","","","","","",""]
-        }, 
+        },
         {
           id:2,
           state: ["","","","","","","","",""]
@@ -355,7 +355,7 @@ describe('#integration tests of persistence', function() {
         ]
       }
       var response = {
-        "status": 200, 
+        "status": 200,
         "contentType": 'application/json',
         "responseText" : JSON.stringify(data)
       }
@@ -366,7 +366,7 @@ describe('#integration tests of persistence', function() {
   });
 
   it("if i play a game it should autosave at the end of the game", function() {
-    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0">X</td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1">O</td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
+    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0"></td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1"></td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
     attachListeners()
     expect($("#games").children().length).toBe(0);
     jasmine.Ajax.withMock(function() {
@@ -378,7 +378,7 @@ describe('#integration tests of persistence', function() {
       $('[data-x="0"][data-y="2"]').click();
       //     // _X_|_O_|_O_
       //     // _X_|___|___
-      //     //  X |   |   
+      //     //  X |   |
       var request = jasmine.Ajax.requests.mostRecent();
       expect(request.url).toBe('/games');
       expect(request.method).toBe('POST');
@@ -386,7 +386,7 @@ describe('#integration tests of persistence', function() {
   });
 
   it("if i play a game it should autosave and start a new game", function() {
-    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0">X</td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1">O</td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
+    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0"></td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1"></td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
     attachListeners()
     expect($("#games").children().length).toBe(0);
     jasmine.Ajax.withMock(function() {
@@ -398,7 +398,7 @@ describe('#integration tests of persistence', function() {
       $('[data-x="0"][data-y="2"]').click();
       //     // _X_|_O_|_O_
       //     // _X_|___|___
-      //     //  X |   |   
+      //     //  X |   |
       var request = jasmine.Ajax.requests.mostRecent();
       expect(request.url).toBe('/games');
       expect(request.method).toBe('POST');
@@ -409,7 +409,7 @@ describe('#integration tests of persistence', function() {
         }
       }
       var response = {
-        "status": 200, 
+        "status": 200,
         "contentType": 'application/json',
         "responseText" : JSON.stringify(data)
       }
@@ -420,7 +420,7 @@ describe('#integration tests of persistence', function() {
       $('[data-x="2"][data-y="0"]').click();
       //     // _X_|_O_|_O_
       //     // _X_|___|___
-      //     //    |   |   
+      //     //    |   |
       expect(jasmine.Ajax.requests.count()).toBe(1)
       $("#save").click()
       expect(jasmine.Ajax.requests.count()).toBe(2)
@@ -431,7 +431,7 @@ describe('#integration tests of persistence', function() {
   });
 
   it("if should be able to switch to an old game", function() {
-    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0">X</td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1">O</td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
+    setFixtures('<body><table border="1" cellpadding="40"><tr><td data-x="0", data-y="0"></td><td data-x="1", data-y="0"></td><td data-x="2", data-y="0"></td></tr><tr><td data-x="0", data-y="1"></td><td data-x="1", data-y="1"></td><td data-x="2", data-y="1"></td></tr><tr><td data-x="0", data-y="2"></td><td data-x="1", data-y="2"></td><td data-x="2", data-y="2"></td></tr></table><div id="games"></div><div id="message"></div><button id="save">Save Game</button><button id="previous">Show Previous Games</button></body>');
     attachListeners()
     jasmine.Ajax.withMock(function() {
       $('[data-x="0"][data-y="0"]').click();
@@ -440,7 +440,7 @@ describe('#integration tests of persistence', function() {
         games: [{
           id:1,
           state: ["X","","","","","","","",""]
-        }, 
+        },
         {
           id:2,
           state: ["","X","O","","O","","","",""]
@@ -448,7 +448,7 @@ describe('#integration tests of persistence', function() {
         ]
       }
       var response = {
-        "status": 200, 
+        "status": 200,
         "contentType": 'application/json',
         "responseText" : JSON.stringify(data)
       }
@@ -460,5 +460,5 @@ describe('#integration tests of persistence', function() {
       expect($('[data-x="2"][data-y="0"]').text()).toBe("O")
       expect($('[data-x="1"][data-y="1"]').text()).toBe("O")
     });
-  });      
+  });
 });


### PR DESCRIPTION
Some fixtures had an X and O already in the HTML. This caused
some errors when the test would try and click on those spots
in a play through.

Fixes issues #12 

@PeterBell 