### PR TITLE
add note about not naming functions save/previous

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ For the actual TTT functionality, the test suite is pretty opinionated. We've gi
   + Attaches the appropriate event listeners to the squares of the game board as well as for the `button#save`, `button#previous`, and `button#clear` elements.
   + When a user clicks on a square on the game board, the event listener should invoke `doTurn()` and pass it the element that was clicked.
   + ***NOTE***: `attachListeners()` _must_ be invoked inside either a `$(document).ready()` (jQuery) or a `window.onload = () => {}` (vanilla JavaScript). Otherwise, a number of the tests will fail (not to mention that your game probably won't function in the browser).
+  + When you name your save and previous functions, make sure to call them something like `saveGame()` and `previousGames()`. If you call them `save()` and `previous()` you may run into problems with the test suite.
 
 ## Testing
 You can run the test suite in one of two ways:


### PR DESCRIPTION
@curiositypaths 
Spent a long time with a student today getting strange errors when his functions to save games was `save()` and load previous games was called `previous()`. 

I replicated the problem with the solution code. To clarify, the tests still pass in the browser when mocha is in bdd mode, but in the terminal a bunch of errors come up saying save is not a function and previous is not a function. 

This interferes with all of the sinon mock requests and the last third of the tests are broken in the terminal. 

This PR adds a note in here about the problem and recommending that students name the functions something like saveGame() and previousGames().